### PR TITLE
Add moderator notification email functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Craft plugin for simple user moderation. This plugin does the following:
 
 1. The user is set in a pending state if their email address isn't one of the approved domains.
 1. The user receives an email saying that their account request has been received.
+1. Optional: A moderator gets a notification email about the new signup.
 
 ## When an admin activates the user:
 
@@ -23,33 +24,59 @@ Craft plugin for simple user moderation. This plugin does the following:
 
 If you want users with specific domain names to be automatically approved, enter those domain names with each one on a separate line.
 
-### Sign Up Email
+### User Signup Email
 
 This is the email that is sent to a user when they sign up.
 
-#### Subject
+#### User Signup Email Subject
 
 *Default:* User Request Received
 
-#### Body
+#### User Signup Email Body
 
 You have access to a Twig `{{ user }}` variable, which is a <a href="http://buildwithcraft.com/docs/templating/usermodel">UserModel</a>.
 
 *Default:* We received your request for a members account and we are currently reviewing it.  You will receive a verification email once the account has been approved.
 
-### Activation Email
+### User Activation Email
 
 This is the email that is sent to a user when they are activated.
 
-#### Subject
+#### User Activation Email Subject
 
 *Default:* Account Activated
 
-#### Body
+#### User Activation Email Body
 
 You have access to a Twig `{{ user }}` variable, which is a <a href="http://buildwithcraft.com/docs/templating/usermodel">UserModel</a>.
 
 *Default:* Your account has been activated.
+
+### Moderator Notification Email
+
+This is the email the moderator will get whenever a new user signs up.
+
+#### Enable Moderator Email Notification
+
+If this is enabled, the moderator will get an email whenever a new user signs up.
+
+*Default:* Off
+
+#### Moderator Email Address
+
+The email address the notification will be sent to.
+
+*Default:* The site administrator's email address.
+
+#### Moderator Notification Email Subject
+
+*Default:* A new user has signed up
+
+#### Moderator Notification Email Body
+
+You have access to a Twig `{{ user }}` variable, which is a <a href="http://buildwithcraft.com/docs/templating/usermodel">UserModel</a>. Use `{{ user.cpEditUrl }}` to insert a link to the user edit screen.
+
+*Default:* A new user has signed up. Click here to review: `{{ user.cpEditUrl }}`
 
 <hr>
 

--- a/pendinguser/services/PendingUser_EmailService.php
+++ b/pendinguser/services/PendingUser_EmailService.php
@@ -21,9 +21,21 @@ class PendingUser_EmailService extends BaseApplicationComponent
 
     public function signup(UserModel $user)
     {
+        // Send email to user
         $this->email->toEmail = $user->email;
         $this->email->subject = $this->pluginSettings['signupEmailSubject'];
         $this->email->body = craft()->templates->renderString($this->pluginSettings['signupEmailBody'], array(
+            'user' => $user,
+        ));
+
+        craft()->email->sendEmail($this->email);
+    }
+
+    public function notifyModerator(UserModel $user)
+    {
+        $this->email->toEmail = $this->pluginSettings['moderatorEmailAddress'];
+        $this->email->subject = $this->pluginSettings['moderatorEmailSubject'];
+        $this->email->body = craft()->templates->renderString($this->pluginSettings['moderatorEmailBody'], array(
             'user' => $user,
         ));
 

--- a/pendinguser/templates/settings.html
+++ b/pendinguser/templates/settings.html
@@ -13,7 +13,7 @@
   placeholder: 'Example: gmail.com'
 }) }}
 
-<h3>Sign Up Email</h3>
+<h3>User Sign Up Email</h3>
 
 <p>This is the email that is sent to a user when they sign up.</p>
 
@@ -31,7 +31,7 @@
   rows: 10
 }) }}
 
-<h3>Activation Email</h3>
+<h3>User Activation Email</h3>
 
 <p>This is the email that is sent to a user when they are activated.</p>
 
@@ -46,5 +46,34 @@
   instructions: 'You have access to a Twig {{ user }} variable, which is a <a href="http://buildwithcraft.com/docs/templating/usermodel">UserModel</a>.',
   name: 'activationEmailBody',
   value: settings.activationEmailBody,
+  rows: 10
+}) }}
+
+<h3>Moderator Notification Email</h3>
+
+{{ forms.lightswitchField({
+  label: 'Enable Moderator Email Notification',
+  instructions: 'If you enable this, the moderator will get an email whenever a user signs up.',
+  name: 'notifyModerator',
+  on: settings.notifyModerator
+}) }}
+
+{{ forms.textField({
+  label: 'Moderator Email Address',
+  name: 'moderatorEmailAddress',
+  value: settings.moderatorEmailAddress
+}) }}
+
+{{ forms.textField({
+  label: 'Moderator Notification Email Subject',
+  name: 'moderatorEmailSubject',
+  value: settings.moderatorEmailSubject
+}) }}
+
+{{ forms.textareaField({
+  label: 'Moderator Notification Email Body',
+  instructions: 'You have access to a Twig {{ user }} variable, which is a <a href="http://buildwithcraft.com/docs/templating/usermodel">UserModel</a>.',
+  name: 'moderatorEmailBody',
+  value: settings.moderatorEmailBody,
   rows: 10
 }) }}


### PR DESCRIPTION
Thanks for the plugin! We needed a way to notify the client whenever a new user signs up. This adds an optional, configurable moderator notification email functionality.
