### PR TITLE
prevent user activation if not done by user with correct privileges

### DIFF
--- a/pendinguser/PendingUserPlugin.php
+++ b/pendinguser/PendingUserPlugin.php
@@ -94,6 +94,14 @@ class PendingUserPlugin extends BasePlugin
             $user = $event->params['user'];
             craft()->pendingUser_email->activate($user);
         });
+
+        craft()->on('users.onBeforeActivateUser', function (Event $event) {
+            // stop the user from being able to activate their account. Forces admins or users with sufficient privileges to do so.
+            $loggedInUser = craft()->userSession->getUser();
+            if (!$loggedInUser || (!craft()->userSession->isAdmin() && !craft()->userPermissions->doesUserHavePermission($loggedInUser->id, 'registerUsers'))) {
+                $event->performAction = false;
+            }
+        });
     }
 
     private function isAllowedDomain($domain)


### PR DESCRIPTION
This checks if the user activation is coming from a logged in user with sufficient privileges, and blocks it if not (when the activation is a result of resetting a password or verifying an email address). This addresses issue #6 